### PR TITLE
Fix strict warning by removing hack

### DIFF
--- a/update_database.php
+++ b/update_database.php
@@ -100,8 +100,7 @@ function manual_step_confirm() {
 function run_migration($version, $filename) {
 	global $db;
 	try {
-		$parts = explode('.', $filename);
-		$ext = end($parts);
+		$ext = pathinfo($filename,  PATHINFO_EXTENSION);
 		ColorTerminal::set("blue");
 		echo "============= BEGIN $filename =============\n";
 		ColorTerminal::set("normal");


### PR DESCRIPTION
Using `pathinfo` to extract the file extension.
