### PR TITLE
ask_for_password output buffering support

### DIFF
--- a/update_database.php
+++ b/update_database.php
@@ -56,6 +56,7 @@ if(isset($argv[1])) {
 
 function ask_for_password() {
 	echo "Password: ";
+	ob_flush();
 	flush();
 	system('stty -echo');
 	$password = trim(fgets(STDIN));


### PR DESCRIPTION
If output buffering is enabled by config.php or one of its includes, the password prompt disappears. This commit fixes this.
